### PR TITLE
Support custom checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Ping mongodb every x seconds to prevent disconnections.
+Ping MongoDB every x seconds to prevent disconnects.
 
 ## Installation
 
@@ -9,12 +9,11 @@ npm i mongo-heartbeat
 ## Usage
 
 ```
-
 var MongoHeartbeat = require('mongo-heartbeat');
 
 var hb = MongoHeartbeat(db, {
-  interval: 5000, //defaults to 5000 ms,
-  timeout: 10000  //defaults to 10000 ms
+  interval: 5000, //defaults to 5000 ms
+  timeout: 10000, //defaults to 10000 ms
   tolerance: 2    //defaults to 1 attempt
 });
 
@@ -26,11 +25,39 @@ hb.on('error', function (err) {
 });
 ```
 
+## Custom Checks
+
+By default the heartbeat will send a ping to MongoDB, but you can override this with your own logic (eg: query a collection). It would be advisable to run a query/command which has a low impact on your database (like querying a collection with a few records for example).
+
+```
+var MongoHeartbeat = require('mongo-heartbeat');
+
+var hb = MongoHeartbeat(db, {
+  interval: 5000,
+  timeout: 10000,
+  tolerance: 2,,
+  checkHandler: function(database, cb) {
+    database.collection('someCollectionWithFewRecords').find({ }, cb);
+  }
+});
+
+hb.on('error', function (err) {
+  console.error('mongodb didnt respond the heartbeat message or the check failed', err);
+  process.nextTick(function () {
+    process.exit(1);
+  });
+});
+```
+
 ## Debug
 
 This module uses the [debug](https://github.com/visionmedia/debug) module, use as follows:
 
 DEBUG=mongo-heartbeat node server
+
+## Testing
+
+Use `npm run test` to run the unit tests (make sure MongoDB is running on `mongodb://localhost/test`).
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -9,7 +9,10 @@ var EventEmitter = require('events').EventEmitter;
 var defaults = {
   timeout: 10000,
   interval: 5000,
-  tolerance: 1
+  tolerance: 1,
+  checkHandler: function(db, callback) {
+    db.command({ping: 1}, callback);
+  }
 };
 
 function Pinger(db, options) {
@@ -36,7 +39,7 @@ Pinger.prototype._check = function check(callback) {
     return callback(err);
   }
 
-  db.command({ping: 1}, cb(function (err) {
+  self._options.checkHandler(db, cb(function (err) {
     self._current_failures = err ? (self._current_failures + 1) : 0;
     if (err && self._current_failures >= self._options.tolerance) {
       var error = err;


### PR DESCRIPTION
We came across a situation where the MongoDB ping worked fine, but actual queries failed. This is why it could be useful to override the default ping check with custom logic (like querying a small collection)