### PR TITLE
Update debug to version 2.6.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+<a name="v2.0.1"></a>
+# v2.0.1
+- Bump the version of `debug` from 2.2.0 to 2.6.9.  The previous version had a Regular Expression Denial of Service bug https://snyk.io/test/npm/debug/2.2.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo-heartbeat",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Ping mongodb every x seconds to prevent disconnections",
   "main": "index.js",
   "scripts": {
@@ -14,7 +14,7 @@
   "license": "MIT",
   "dependencies": {
     "cb": "~0.1.0",
-    "debug": "~2.2.0",
+    "debug": "~2.6.9",
     "xtend": "~3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Bump the version of `debug` from 2.2.0 to 2.6.9.  The previous version had a Regular Expression Denail of Service bug https://snyk.io/test/npm/debug/2.2.0